### PR TITLE
REFACTOR BUG FIX: 설정으로 가는 Alert추가, notification 로직 분리,

### DIFF
--- a/RecordManagment/ContentView.swift
+++ b/RecordManagment/ContentView.swift
@@ -23,7 +23,6 @@ struct ContentView: View {
                     coordinator.build(fullScreenCover: cover)
                 }
         }
-        .tint(Color(hex: "#212121"))
         .environmentObject(coordinator)
         .environmentObject(rm)
     }

--- a/RecordManagment/UseCases/NotificationService.swift
+++ b/RecordManagment/UseCases/NotificationService.swift
@@ -6,6 +6,11 @@
 //
 
 import UserNotifications
+import UIKit
+
+enum UserDefaultKey {
+    static let didAskNotificationPermission = "didAskNotificationPermission"
+}
 
 class NotificationService {
     let center = UNUserNotificationCenter.current()
@@ -17,22 +22,35 @@ class NotificationService {
                 if let err = err {
                     debugPrint("알림 권한 요청 실패 : \(err.localizedDescription)")
                 }
+                
+                if !grant {
+                    UserDefaults.standard.set(true, forKey: UserDefaultKey.didAskNotificationPermission)
+                }
                 continuation.resume(returning: grant)
             }
         }
     }
     
-    // 알림 권한 확인
-    func checkNotificationAuthorizationStatus() async -> Bool {
+    // 알림 권한 상태 확인 (상세한 상태 반환)
+    func getNotificationAuthorizationStatus() async -> UNAuthorizationStatus {
         await withCheckedContinuation { continuation in
             center.getNotificationSettings { settings in
-                switch settings.authorizationStatus {
-                case .authorized, .provisional, .ephemeral:
-                    continuation.resume(returning: true)
-                default:
-                    continuation.resume(returning: false)
-                }
+                continuation.resume(returning: settings.authorizationStatus)
             }
+        }
+    }
+
+    // 앱 설정 화면으로 이동하는 함수
+    @MainActor
+    func openAppSettings() async {
+        await withCheckedContinuation { continuation in
+            guard let url = URL(string: UIApplication.openSettingsURLString),
+                  UIApplication.shared.canOpenURL(url) else {
+                debugPrint("설정 화면을 열 수 없습니다.")
+                return
+            }
+            UIApplication.shared.open(url)
+            continuation.resume()
         }
     }
 }

--- a/RecordManagment/View/OnBoarding/SectionFiveView.swift
+++ b/RecordManagment/View/OnBoarding/SectionFiveView.swift
@@ -32,6 +32,7 @@ struct SectionFiveView: View {
                       }
                   }) {
                       Image(systemName: "chevron.left")
+                          .foregroundStyle(Color(hex: "#212121"))
                   }
             }
         }

--- a/RecordManagment/View/OnBoarding/SectionFourView.swift
+++ b/RecordManagment/View/OnBoarding/SectionFourView.swift
@@ -51,6 +51,7 @@ struct SectionFourView: View {
                       }
                   }) {
                       Image(systemName: "chevron.left")
+                          .foregroundStyle(Color(hex: "#212121"))
                   }
             }
         }

--- a/RecordManagment/View/OnBoarding/SectionOneView.swift
+++ b/RecordManagment/View/OnBoarding/SectionOneView.swift
@@ -98,6 +98,7 @@ struct SectionOneView: View {
                     coordinator.pop()
                 }) {
                     Image(systemName: "chevron.left")
+                        .foregroundStyle(Color(hex: "#212121"))
                 }
                 .opacity(coordinator.getCurrentStack() > 1 ? 1 : 0)
             }

--- a/RecordManagment/View/OnBoarding/SectionThreeView.swift
+++ b/RecordManagment/View/OnBoarding/SectionThreeView.swift
@@ -54,6 +54,7 @@ struct SectionThreeView: View {
                       }
                   }) {
                       Image(systemName: "chevron.left")
+                          .foregroundStyle(Color(hex: "#212121"))
                   }
             }
         }

--- a/RecordManagment/View/OnBoarding/SectionTwoView.swift
+++ b/RecordManagment/View/OnBoarding/SectionTwoView.swift
@@ -87,6 +87,7 @@ struct SectionTwoView: View {
                       }
                   }) {
                       Image(systemName: "chevron.left")
+                          .foregroundStyle(Color(hex: "#212121"))
                   }
             }
         }

--- a/RecordManagment/View/OnBoarding/SectionView.swift
+++ b/RecordManagment/View/OnBoarding/SectionView.swift
@@ -44,7 +44,19 @@ struct SectionView: View {
                     // 알림 허용 기능
                     if vm.currentProgress == .notification {
                         Task {
-                            await vm.requestPermisson()
+                            let askedNotice = UserDefaults.standard.bool(forKey: UserDefaultKey.didAskNotificationPermission)
+                            
+                            if askedNotice {
+                                let grant = await vm.requestPermisson()
+                                if !grant {
+                                    vm.isGrantAlert = true
+                                }else {
+                                    vm.isGrant = grant
+                                }
+                            } else {
+                                let grant = await vm.requestPermisson()
+                                vm.isGrant = grant
+                            }
                         }
                     } else {
                         next(vm.currentProgress)
@@ -70,6 +82,23 @@ struct SectionView: View {
                             coordinator.push(.finalOnBoarding(message: "알림 설정이 거부되었습니다.", sm: vm))
                         }
                     }
+                }
+            }
+            .alert("알림 권한", isPresented: $vm.isGrantAlert, actions: {
+                Button("설정으로 이동") {
+                    Task {
+                        await vm.moveAppSetting()
+                    }
+                }
+                Button("취소", role: .cancel) {
+                    vm.isGrant = false
+                }
+            }, message: {
+                Text("알림 권한을 허용하면 알림을 받을 수 있어요")
+            })
+            .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
+                Task {
+                    await vm.checkPermission()
                 }
             }
         }

--- a/RecordManagment/ViewModel/SectionView+ViewModel.swift
+++ b/RecordManagment/ViewModel/SectionView+ViewModel.swift
@@ -19,7 +19,7 @@ extension SectionView {
         @Published var selectGoal: SectionFourView.GoalTypes = .none
         @Published var isGrant: Bool? = nil
         @Published var selectedDate: Date = .now
-        
+        @Published var isGrantAlert: Bool = false
         let noticeService: NotificationService = .init()
         let networkManager: SectionNetworkManager = .init()
         
@@ -57,9 +57,25 @@ extension SectionView {
         
         
         // TODO: Notification 권한 허용 함수
-        func requestPermisson() async {
+        func requestPermisson() async -> Bool {
              let grant = await noticeService.requestNotificationPermission()
-             self.isGrant = grant
+             return grant
+        }
+        
+        // TODO: 앱 설정에서 권한 허용 시점에 grant 변경
+        func checkPermission() async {
+            let grant = await noticeService.getNotificationAuthorizationStatus()
+            switch grant {
+                case .authorized, .provisional, .ephemeral:
+                    self.isGrant = true
+                default:
+                    self.isGrant = false
+            }
+        }
+        
+        // TODO: 앱 권한이 없을 경우 앱 세팅으로 보내는 함수
+        func moveAppSetting() async {
+            await noticeService.openAppSettings()
         }
         
         // TODO: OnBoarding 전달 함수
@@ -80,19 +96,12 @@ extension SectionView {
         
         // TODO: 온보딩 객체 생성 함수
         func makeOnBoardingDTO() async -> OnBoardingDTO? {
-            // 저장된 값 확인
-            guard let isGrant, isGrant else { return nil }
-            
-            // 최신 권한 상태 확인
-            let granted = await noticeService.checkNotificationAuthorizationStatus()
-            guard granted else { return nil }
-            
             return OnBoardingDTO(
                 nickName: name,
                 mainRecordType: currentRecord.localizedString(),
                 birthDate: Date.onBoardingFormet(selectedDate),
                 goalDays: selectGoal.localizedInt(),
-                notificationEnabled: granted
+                notificationEnabled: isGrant ?? false
             )
         }
     }


### PR DESCRIPTION
### Bug Fix: System Alert는 앱 실행 시 한번만 나와서 온보딩 과정중 처리 로직이 없음

> [!WARNING]
> 1. 앱 세팅으로 보내는 Alert 추가
> 2. UserDefaults로 앱의 권한 수락을 하지 않을 시 추가 그 외는 SystemAlert가 처리 함
> 3. 취소 -> 온보딩 진행, 설정으로 이동 -> 앱 설정 가서 알림 추가 또는 X
> 4. 백그라운드에서 돌아올 때 앱의 권한 Check를 통해 다음 온보딩 넘기기

