### PR TITLE
Calendar Records 뷰 업데이트 갱신 버그 fix

### DIFF
--- a/RecordManagment/Components/Calendar/CalendarView.swift
+++ b/RecordManagment/Components/Calendar/CalendarView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct CalendarView: View {
-    @StateObject private var vm: ViewModel = .init()
+    @ObservedObject var vm: ViewModel // Calendar ViewModel
     @EnvironmentObject var sheetVM: MainSheetViewModel
     @State private var focusedWeek: Week = .current
     @State private var title: String = Calendar.monthAndYear(from: .now)
@@ -101,5 +101,5 @@ extension CalendarView {
 }
 
 #Preview {
-    CalendarView()
+    CalendarView(vm: .init())
 }

--- a/RecordManagment/Model/CalendarDetail.swift
+++ b/RecordManagment/Model/CalendarDetail.swift
@@ -15,7 +15,7 @@ struct CalendarDetailData: Codable {
 }
 
 /// ** 공통 프로퍼티
-struct RecordResponse: Codable, Identifiable, Equatable {
+struct RecordResponse: Codable, Identifiable, Equatable, Hashable {
     let id: String
     let type: String
     let recordDate: [Int]
@@ -25,7 +25,7 @@ struct RecordResponse: Codable, Identifiable, Equatable {
 }
 
 /// ** 일정 기록
-struct DailyResponse: Codable, Equatable {
+struct DailyResponse: Codable, Equatable, Hashable {
     let base: RecordResponse
     let emotion: String
     let content: String
@@ -68,7 +68,7 @@ struct DailyResponse: Codable, Equatable {
 }
 
 /// ** 운동 기록
-struct ExerciseResponse: Codable {
+struct ExerciseResponse: Codable, Equatable, Hashable {
     let base: RecordResponse
     let exerciseType: String
     let caloriesBurned: Int?
@@ -154,23 +154,5 @@ enum IntergrationRecord: Codable, Hashable, Equatable {
         }
     }
     
-    func hash(into hasher: inout Hasher) {
-        switch self {
-            case .daily(let dailyResponse):
-                hasher.combine("dailyResponse-\(dailyResponse.base.id)")
-            case .exercise(let exerciseResponse):
-                hasher.combine("exercise-\(exerciseResponse.base.id)")
-        }
-    }
     
-    static func == (lhs: IntergrationRecord, rhs: IntergrationRecord) -> Bool {
-        switch (lhs, rhs) {
-            case (.daily(let res1), .daily(let res2)):
-                return res1.base.id == res2.base.id
-            case (.exercise(let res1), .exercise(let res2)):
-                return res1.base.id == res2.base.id
-            default:
-                return false
-        }
-    }
 }

--- a/RecordManagment/UseCases/RecordService.swift
+++ b/RecordManagment/UseCases/RecordService.swift
@@ -9,15 +9,23 @@ class RecordService: ObservableObject {
     @Published var selectedDate: Date? = .now
 
     private var cancellables = Set<AnyCancellable>()
+    let refreshSubject = PassthroughSubject<Void, Never>() // records update를 위한 Publisher
     private var keyChain: KeyChainManager = .shared
     private let common: IntergrationManager = .shared
     let imageService: FetchImageUseCases = .init()
 
     private init() {
-        $selectedDate
-            .prepend(selectedDate)
+        let dateChangePublisher = $selectedDate
             .compactMap { $0 }
             .removeDuplicates()
+
+        let refreshPublisher = refreshSubject
+            .compactMap { [weak self] in
+                return self?.selectedDate
+            }
+
+        Publishers.Merge(dateChangePublisher, refreshPublisher)
+            .prepend(selectedDate ?? .now)
             .sink { [weak self] date in
                 Task {
                     await self?.fetchDateForDetailRecords(for: date)
@@ -52,9 +60,10 @@ class RecordService: ObservableObject {
             }
             
             let decodedData = try JSONDecoder().decode(CalendarDetail.self, from: data)
+            objectWillChange.send()
             if let records = decodedData.data?.records {
                 self.detailRecords = records
-                print(detailRecords)
+                print("특정 날짜 없데이트!! : \(date)")
             } else {
                 self.detailRecords = []
             }

--- a/RecordManagment/View/Main/MainSheet.swift
+++ b/RecordManagment/View/Main/MainSheet.swift
@@ -10,6 +10,7 @@ struct MainSheet: View {
     @EnvironmentObject var rm: RouterView.ViewModel
     @EnvironmentObject private var vm: MainSheetViewModel
     @StateObject var calendarVM: CalendarView.ViewModel = .init()
+    @StateObject private var recordService = RecordService.shared
     var loginManager: LoginNetworkManager = .init()
     
     init(offset: CGFloat, topDetent: CGFloat, sheetState: Binding<SheetState>) {
@@ -33,28 +34,32 @@ struct MainSheet: View {
                             // minY는 스크롤 다운 시 음수로 내려가므로, 양수 오프셋으로 변환
                             scrollOffset = -minY
                         }
-                    CalendarView()
+                    CalendarView(vm: calendarVM)
                         .environmentObject(vm)
                         .padding(.top, 9)
                     Group {
                         Divider()
-                        if let currentDate = vm.recordService.selectedDate, !vm.recordService.detailRecords.isEmpty {
+                        if let currentDate = recordService.selectedDate, !recordService.detailRecords.isEmpty {
                             Text(Date.dailyRecordDateFormat(currentDate))
                                 .typography(.p18SemiBold)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .padding(.vertical, 24)
                         }
                         VStack {
-                            ForEach(vm.recordService.detailRecords, id: \.self) { record in
+                            ForEach(recordService.detailRecords, id: \.self) { record in
                                 switch record {
-                                    case .daily(let dailyInfo):
-                                        DailyView(dailyInfo: dailyInfo)
-                                    case .exercise(let exerciseInfo):
-                                        EmptyView()
+                                case .daily(let dailyInfo):
+                                    DailyView(dailyInfo: dailyInfo)
+                                case .exercise(let exerciseInfo):
+                                    EmptyView()
                                 }
                             }
                         }
-                        .id(vm.visibleToast)
+                        .onChange(of: vm.visibleToast) {
+                            if vm.visibleToast {
+                                recordService.refreshSubject.send()
+                            }
+                        }
                     }
                     .padding(.horizontal)
                     testBox()

--- a/RecordManagment/ViewModel/CalenderView+ViewModel.swift
+++ b/RecordManagment/ViewModel/CalenderView+ViewModel.swift
@@ -18,13 +18,6 @@ extension CalendarView {
         private let common: IntergrationManager = .shared
         
         init() {
-            recordService.objectWillChange
-                .receive(on: RunLoop.main)
-                .sink { [weak self] _ in
-                    self?.objectWillChange.send()
-                }
-                .store(in: &cancellables)
-            
             dateAndRecordCalenderInfoSubscriber()
             $date
                 .sink { [weak self] date in


### PR DESCRIPTION
:link: 관련 이슈
Hashable은 SwiftUI가 뷰 업데이트를 인지하기 위한 프로토콜임을 깨달았다 
분명 업데이트된 출력이 보이는데 뷰가 업데이트가 안된다면 ForEach와 모델의 Protocol을 확인하자..

:orange_book: 작업 설명
Records의 뷰 갱신 버그를 해결하였다.
Calendar 중복 생성을 찾아서 제거.
특정 날짜의 선택 Stream과 뷰 갱신 스트림을 분리해서 Merge 하였다. -> removeDuplicated를 적용 시킬 수 있음

:test_tube: 테스트 내역 (선택)
api 테스트, repository 테스트 작성

:camera_with_flash: 스크린샷 또는 시연 영상 (선택)

:speech_balloon: 추가 설명 or 리뷰 포인트 (선택)