### PR TITLE
Qa 19/목표 달성 리포트 버그 수정 및 목표 재설정 테스트 코드 추가

### DIFF
--- a/RecordManagment/Data/DefaultSettingRepository.swift
+++ b/RecordManagment/Data/DefaultSettingRepository.swift
@@ -88,4 +88,27 @@ class DefaultSettingRepository: SettingRepository {
         
         return result
     }
+    
+    func apiTest() async throws {
+        guard let domain = await common.manager.domain,
+              let url = URL(string: "\(domain)/api/goals/current/force-complete") else {
+            throw LoginError.networkError(.invalidURL(url: "/api/goals/current/force-complete"))
+        }
+
+        guard let accessToken = await common.manager.keyChain.read(account: "accessToken") else {
+            throw LoginError.notToken
+        }
+
+        let headers: HTTPHeaders = [
+            "Authorization": "Bearer \(accessToken)"
+        ]
+
+        try await AF.request(
+            url,
+            method: .patch,
+            headers: headers
+        )
+        .serializingData()
+        .value
+    }
 }

--- a/RecordManagment/Domain/Entitiy/Goal/GoalAchieve.swift
+++ b/RecordManagment/Domain/Entitiy/Goal/GoalAchieve.swift
@@ -1,23 +1,38 @@
 import Foundation
 
 struct GoalAchieve: Decodable {
+    let statusCode: Int
+    let code: String
+    let message: String
     let data: GoalData?
-    let achieveCount: Int?
-    
-    enum CodingKeys: String, CodingKey {
-        case data = "currentPeriod"
-        case achieveCount = "cumulativeAchievementCount"
-    }
 }
 
 struct GoalData: Decodable {
+    let currentPeriod: CurrentPeriodData?
+    let cumulativeAchievementCount: Int
+    let recentHistory: [RecentHistoryData?]
+}
+
+struct CurrentPeriodData: Decodable {
     let goalId: String
     let recordType: String
     let goalDays: Int
-    let startDate: String
-    let endDate: String
+    let startDate: [Int]
+    let endDate: [Int]
     let completedDays: Int
     let achievementRate: Int
     let treeStage: String
-    let isInProgress: Bool
+    let isInProgress: Bool?
+}
+
+struct RecentHistoryData: Decodable {
+    let goalId: String
+    let recordType: String
+    let goalDays: Int
+    let startDate: [Int]
+    let endDate: [Int]
+    let completedDays: Int
+    let achievementRate: Int
+    let finalTreeStage: String
+    let status: String
 }

--- a/RecordManagment/Domain/Repository/SettingRepository.swift
+++ b/RecordManagment/Domain/Repository/SettingRepository.swift
@@ -6,4 +6,7 @@ protocol SettingRepository {
     func notificationRecordUpdate(data: NotificationSettingRequestBody) async -> Result<NotificationSettingDTO, LoginError>
     // 초기 알림 Init 함수
     func initStateNotificationSetting() async -> Result<NotificationSettingDTO, LoginError>
+    
+    // 목표 재설정 Test API Code
+    func apiTest() async throws
 }

--- a/RecordManagment/Domain/UseCase/SettingUseCase.swift
+++ b/RecordManagment/Domain/UseCase/SettingUseCase.swift
@@ -47,4 +47,8 @@ class SettingUseCase {
                 throw failure
         }
     }
+    
+    func test() async throws {
+        try await repository.apiTest()
+    }
 }

--- a/RecordManagment/Presentation/Coordinator/Coordinator.swift
+++ b/RecordManagment/Presentation/Coordinator/Coordinator.swift
@@ -127,7 +127,7 @@ enum FullScreenCover: Equatable, Identifiable, Hashable {
     case dailyRecord(emotion: EmotionObj)
     case exerciseRecord(exercise: ExerciseObj)
     case habitRecord(habit: HabitObj, recordVM: RecordViewModel)
-    case achievementGoal(goal: GoalAchieve)
+    case achievementGoal(goal: RecentHistoryData, achiveCount: Int)
     
     var id: String {
         switch self {
@@ -139,7 +139,7 @@ enum FullScreenCover: Equatable, Identifiable, Hashable {
                 return "exerciseRecord-\(exercise.id)"
             case .habitRecord(let habit, _):
                 return "habitRecord-\(habit.id)"
-            case .achievementGoal(_):
+            case .achievementGoal(_,_):
                 return "AchievementGoal"
         }
     }
@@ -165,8 +165,8 @@ enum FullScreenCover: Equatable, Identifiable, Hashable {
                 hasher.combine("exerciseRecord-\(exercise.id)")
             case .habitRecord(let habit, _):
                 hasher.combine("habitRecord-\(habit.id)")
-            case .achievementGoal(let goal):
-                hasher.combine("achievementGoal-\(goal.achieveCount)")
+            case .achievementGoal(_, let achieveCount):
+                hasher.combine("achievementGoal-\(achieveCount)")
         }
     }
 }
@@ -263,8 +263,8 @@ final class Coordinator: ObservableObject {
                 HabitRecordView(habit: habit)
                     .environmentObject(sheetVM)
                     .environmentObject(recordVM)
-            case .achievementGoal(let goal):
-                AchivementGoalFullScreen(goal: goal)
+            case .achievementGoal(let goal, let achieveCount):
+                AchivementGoalFullScreen(goal: goal, achiveCount: achieveCount)
         }
     }
 }

--- a/RecordManagment/Presentation/View/Goal/AchivementGoalFullScreen.swift
+++ b/RecordManagment/Presentation/View/Goal/AchivementGoalFullScreen.swift
@@ -2,7 +2,12 @@ import SwiftUI
 
 struct AchivementGoalFullScreen: View {
     @EnvironmentObject var coordinator: Coordinator
-    let goal: GoalAchieve
+    
+    // View Properties
+    @AppStorage("\(Date.onBoardingFormet(.now))") private var isTodayOpen: Bool = false
+
+    let goal: RecentHistoryData
+    let achiveCount: Int // cumulativeAchievementCount parsing
     
     var body: some View {
         NavigationStack {
@@ -19,16 +24,13 @@ struct AchivementGoalFullScreen: View {
                     )
                     .frame(width: 255,height: 140)
                     .offset(y: 26)
-                
-                if let data = goal.data {
-                    ZStack {
-                        Image(Stage.matchingStage(str: data.treeStage).imageName)
-                            .resizable()
-                            .scaledToFit()
-                            
-                    }
-                    .offset(y: -140)
+                                
+                ZStack {
+                    Image(Stage.matchingStage(str: goal.finalTreeStage).imageName)
+                        .resizable()
+                        .scaledToFit()
                 }
+                .offset(y: -140)
                 
                 bottomSheet
             }
@@ -50,13 +52,14 @@ struct AchivementGoalFullScreen: View {
             }
             .overlay(alignment: .top) {
                 VStack {
-                    if let data = goal.data {
-                        Text(Stage.matchingStage(str: data.treeStage).title)
-                            .typography(.p22Bold)
-                    }
+                    Text(Stage.matchingStage(str: goal.finalTreeStage).title)
+                        .typography(.p22Bold)
                     Spacer()
                 }
                 .padding(.top, 10)
+            }
+            .onAppear {
+                isTodayOpen = true
             }
         }
     }
@@ -94,8 +97,8 @@ struct AchivementGoalFullScreen: View {
 extension AchivementGoalFullScreen {
     // Header View - Bottom Sheet
     var header: some View {
-        let startDate = goal.data?.startDate.replacingOccurrences(of: "-", with: ".") ?? ""
-        let endDate = goal.data?.endDate.replacingOccurrences(of: "-", with: ".") ?? ""
+        let startDate = "\(goal.startDate[0]).\(goal.startDate[1]).\(goal.startDate[2])."
+        let endDate = "\(goal.endDate[0]).\(goal.endDate[1]).\(goal.endDate[2])."
         
         return HStack(spacing: 16) {
             VStack(spacing: 2) {
@@ -165,11 +168,10 @@ extension AchivementGoalFullScreen {
 // MARK: Data Structure
 extension AchivementGoalFullScreen {
     var data: [Int] {
-        guard let data = goal.data else { return [] }
-        return [
-            data.achievementRate,
-            data.completedDays,
-            goal.achieveCount ?? 0
+        [
+            goal.achievementRate,
+            goal.completedDays,
+            achiveCount
         ]
     }
     
@@ -260,23 +262,24 @@ extension AchivementGoalFullScreen {
         }
     }
 }
-
-#Preview {
-    AchivementGoalFullScreen(
-        goal: GoalAchieve(
-            data: GoalData(
-                goalId: "550e8400-e29b-41d4-a716-446655440000",
-                recordType: "HABIT",
-                goalDays: 20,
-                startDate: "2025-11-01",
-                endDate: "2025-11-20",
-                completedDays: 7,
-                achievementRate: 35,
-                treeStage: "STAGE_4",
-                isInProgress: true
-            ),
-            achieveCount: 3
-        )
-    )
-    .environmentObject(Coordinator())
-}
+//
+//#Preview {
+//    AchivementGoalFullScreen(
+//        goal: GoalAchieve(
+//            data: GoalData(
+//                goalId: "550e8400-e29b-41d4-a716-446655440000",
+//                recordType: "HABIT",
+//                goalDays: 20,
+//                startDate: "2025-11-01",
+//                endDate: "2025-11-20",
+//                completedDays: 7,
+//                achievementRate: 35,
+//                treeStage: "STAGE_4",
+//                isInProgress: true
+//            ),
+//            achieveCount: 3,
+//            recentHistory: []
+//        )
+//    )
+//    .environmentObject(Coordinator())
+//}

--- a/RecordManagment/Presentation/View/Main/MainView.swift
+++ b/RecordManagment/Presentation/View/Main/MainView.swift
@@ -10,6 +10,9 @@ struct MainView: View {
     @EnvironmentObject var rm: RouterView.ViewModel
     @EnvironmentObject var coordinator: Coordinator
     @EnvironmentObject var sheetVM: MainSheetViewModel
+    
+    // View Properties
+    @AppStorage("\(Date.onBoardingFormet(.now))") private var hasOpenReport: Bool = false
     @State private var offset: CGFloat = 0
     @State private var topDetent: CGFloat = 0
     
@@ -135,21 +138,19 @@ struct MainView: View {
                     }
             }
         }
-        .onAppear {
-            Task {
-                selectionVM.currentRecord = await selectionVM.getCurrentRecordType()
-                selectionVM.originalRecord = selectionVM.currentRecord // 저장
-            }
-        }
         .task {
+            selectionVM.currentRecord = await selectionVM.getCurrentRecordType()
+            selectionVM.originalRecord = selectionVM.currentRecord // 저장
+            
             guard let user = selectionVM.user.data else { return }
             debugPrint("user : \(user)")
             let goal = await rm.achieveGoal(userId: user.id)
-            
-            if let goal = goal {
-                debugPrint("goal : \(goal)")
-                guard let _ = goal.data else { return }
-                coordinator.present(.achievementGoal(goal: goal))
+            if let data = goal?.data {
+                debugPrint("data : \(data)")
+                if data.currentPeriod == nil && !hasOpenReport {
+                    guard let recentHistory = data.recentHistory[0], !data.recentHistory.isEmpty else { return }
+                    coordinator.present(.achievementGoal(goal: recentHistory, achiveCount: data.cumulativeAchievementCount))
+                }
             }
         }
         .task {

--- a/RecordManagment/Presentation/View/Setting/SettingView.swift
+++ b/RecordManagment/Presentation/View/Setting/SettingView.swift
@@ -83,6 +83,11 @@ struct SettingView: View {
                                             return
                                         case .inQuiry:
                                             UIApplication.shared.open(URL(string: inQueryURL)!, options: [:], completionHandler: nil)
+                                        case .test:
+                                            Task {
+                                                await vm.testGoalInit()
+                                                coordinator.pop()
+                                            }
                                         default:
                                             return
                                     }
@@ -155,6 +160,7 @@ extension SettingView {
             case inQuiry        // 문의 하기
             case logout         // 로그아웃
             case withdraw       // 탈퇴하기
+            case test           // 목표 재설정 테스트
         }
     }
     
@@ -181,7 +187,8 @@ extension SettingView {
                     InnerData(title: "약관 및 정책", next: true, state: .policies),
                     InnerData(title: "문의하기", next: true, state: .inQuiry),
                     InnerData(title: "로그아웃", next: false, state: .logout),
-                    InnerData(title: "탈퇴하기", next: false, state: .withdraw)
+                    InnerData(title: "탈퇴하기", next: false, state: .withdraw),
+                    InnerData(title: "목표 재설정 테스트", next: false, state: .test)
                 ]
             )
         ]

--- a/RecordManagment/Presentation/ViewModel/SettingView+ViewModel.swift
+++ b/RecordManagment/Presentation/ViewModel/SettingView+ViewModel.swift
@@ -252,4 +252,13 @@ extension SettingView.ViewModel {
             debugPrint("초기값 업데이트 실패 : \(error)")
         }
     }
+    
+    // MARK TEST Code
+    func testGoalInit() async {
+        do {
+            try await useCase.test()
+        } catch {
+            debugPrint("error: \(error)")
+        }
+    }
 }


### PR DESCRIPTION
:link: 관련 이슈
currentPeriod가 nil일때 보여줄 목표 달성 리포트는 현재 날짜를 기준으로 AppStorage에 저장해 한번만 보여주고 있지만 
매일 쌓이는 이 값을 제거해줄 필요가 있다.

아니면 서버에서 recentHistory값을 분리하여 currentGoal같은 값을 두고 사용자가 조회하면 null 값으로 전환하는 것도 좋을 거 같습니다.

:orange_book: 작업 설명
> [!TIP]
> 목표 달성 모델링 및 AppStorage를 통해 해당 날짜에 한번 보여주기

> [!NOTE]
> 목표 재설정 테스트 코드 작성을 통해 QA의 편리함 제공
 
:test_tube: 테스트 내역 (선택)

:camera_with_flash: 스크린샷 또는 시연 영상 (선택)

:speech_balloon: 추가 설명 or 리뷰 포인트 (선택)