### PR TITLE
Feature qa 24/calendar next move month

### DIFF
--- a/RecordManagment/Extensions/Components/Calendar/Views/DayView.swift
+++ b/RecordManagment/Extensions/Components/Calendar/Views/DayView.swift
@@ -2,10 +2,12 @@ import SwiftUI
 
 struct DayView: View {
     let cell: DayCell
+    let monthDate: Date
+    
     @Binding var selectedDate: Date
     @Binding var currentRecord: DropDownFilter
     @Binding var calendarRecord: CalendarRecord
-    let monthDate: Date
+    @Binding var selectedMonth: Date
     
     typealias RecordType = (type: DropDownFilter, isCompleted: Bool?)
     
@@ -47,6 +49,7 @@ struct DayView: View {
             withAnimation(.easeInOut) {
                 self.selectedDate = cell.date
             }
+            self.selectedMonth = cell.date
         }
     }
     
@@ -131,9 +134,9 @@ struct DayView: View {
 #Preview {
     DayView(
         cell: DayCell(date: .now),
-        selectedDate: .constant(.now),
+        monthDate: .now, selectedDate: .constant(.now),
         currentRecord: .constant(.all),
         calendarRecord: .constant(CalendarRecord(statusCode: 200, code: "1", message: "Test Message", data: nil)),
-        monthDate: .now
+        selectedMonth: .constant(.now)
     )
 }

--- a/RecordManagment/Extensions/Components/Calendar/Views/MonthCalendarView.swift
+++ b/RecordManagment/Extensions/Components/Calendar/Views/MonthCalendarView.swift
@@ -64,7 +64,8 @@ struct MonthCalendarView: View {
                             focused: $focused,
                             selectedDate: $selection,
                             currentRecord: $currentRecord,
-                            calendarRecord: $calendarRecord
+                            calendarRecord: $calendarRecord,
+                            selectedMonth: $selectedMonth
                         )
                         .frame(width: calendarWidth)
                         .frame(minHeight: month.weeks.count > 5 ? Calendar.monthHeight + 80 : Calendar.monthHeight)
@@ -104,10 +105,37 @@ struct MonthCalendarView: View {
         .onChange(of: selection) { _ ,newValue in
             guard
                   let week = months.flatMap(\.weeks).first(where: { (week) -> Bool in
-                      week.days.contains(where: { Calendar.current.isDate($0.date, inSameDayAs: selection) })
+                      week.days.contains(where: { Calendar.current.isDate($0.date, inSameDayAs: newValue) })
                   })
             else { return }
             focused = week
+            
+            if let newMonth = months.first(where: { Calendar.isSameMonth($0.initializedDate, newValue) }) {
+                
+                if newMonth.id != (position.viewID as? String) {
+                    withAnimation {
+                        position = ScrollPosition(id: newMonth.id)
+                    }
+                }
+            } else {
+                let monthToAdd = Month(from: newValue, order: .current)
+                if newValue < (months.first?.initializedDate ?? .distantPast) {
+                    months.insert(monthToAdd, at: 0)
+                } else if newValue > (months.last?.initializedDate ?? .distantFuture) {
+                    months.append(monthToAdd)
+                } else {
+                    // If it's somewhere in between, try to insert it in the correct order
+                    if let index = months.firstIndex(where: { $0.initializedDate > newValue }) {
+                        months.insert(monthToAdd, at: index)
+                    } else {
+                        months.append(monthToAdd)
+                    }
+                }
+                
+                withAnimation {
+                    position = ScrollPosition(id: monthToAdd.id)
+                }
+            }
         }
         .onChange(of: dragProgress) {_, newValue in
             guard newValue == 1 else { return }

--- a/RecordManagment/Extensions/Components/Calendar/Views/MonthCalendarView.swift
+++ b/RecordManagment/Extensions/Components/Calendar/Views/MonthCalendarView.swift
@@ -113,9 +113,7 @@ struct MonthCalendarView: View {
             if let newMonth = months.first(where: { Calendar.isSameMonth($0.initializedDate, newValue) }) {
                 
                 if newMonth.id != (position.viewID as? String) {
-                    withAnimation {
-                        position = ScrollPosition(id: newMonth.id)
-                    }
+                    position = ScrollPosition(id: newMonth.id)
                 }
             } else {
                 let monthToAdd = Month(from: newValue, order: .current)
@@ -132,9 +130,8 @@ struct MonthCalendarView: View {
                     }
                 }
                 
-                withAnimation {
-                    position = ScrollPosition(id: monthToAdd.id)
-                }
+                
+                position = ScrollPosition(id: monthToAdd.id)
             }
         }
         .onChange(of: dragProgress) {_, newValue in

--- a/RecordManagment/Extensions/Components/Calendar/Views/MonthView.swift
+++ b/RecordManagment/Extensions/Components/Calendar/Views/MonthView.swift
@@ -15,6 +15,7 @@ struct MonthView: View {
     @Binding var selectedDate: Date
     @Binding var currentRecord: DropDownFilter
     @Binding var calendarRecord: CalendarRecord
+    @Binding var selectedMonth: Date
     
     var body: some View {
         VStack(spacing: .zero) {
@@ -26,7 +27,8 @@ struct MonthView: View {
                     selectedDate: $selectedDate,
                     currentRecord: $currentRecord,
                     calendarRecord: $calendarRecord,
-                    monthDate: month.initializedDate
+                    monthDate: month.initializedDate,
+                    selectedMonth: $selectedMonth
                 )
                 .opacity(focused == week ? 1 : dragProgress)
                 .frame(height: Calendar.monthHeight / CGFloat(month.weeks.count))
@@ -45,6 +47,7 @@ struct MonthView: View {
         focused: .constant(.current),
         selectedDate: .constant(.now),
         currentRecord: .constant(.all),
-        calendarRecord: .constant(CalendarRecord(statusCode: 200, code: "1", message: "Test Message", data: nil))
+        calendarRecord: .constant(CalendarRecord(statusCode: 200, code: "1", message: "Test Message", data: nil)),
+        selectedMonth: .constant(.now)
     )
 }

--- a/RecordManagment/Extensions/Components/Calendar/Views/WeekCalendarView.swift
+++ b/RecordManagment/Extensions/Components/Calendar/Views/WeekCalendarView.swift
@@ -70,7 +70,8 @@ struct WeekCalendarView: View {
                             selectedDate: $selection,
                             currentRecord: $currentRecord,
                             calendarRecord: $calendarRecord,
-                            monthDate: .now
+                            monthDate: .now,
+                            selectedMonth: .constant(.now)
                         )
                         .frame(width: calendarWidth, height: 80)
                         .onAppear {

--- a/RecordManagment/Extensions/Components/Calendar/Views/WeekView.swift
+++ b/RecordManagment/Extensions/Components/Calendar/Views/WeekView.swift
@@ -9,8 +9,9 @@ struct WeekView: View {
     @Binding var selectedDate: Date
     @Binding var currentRecord: DropDownFilter
     @Binding var calendarRecord: CalendarRecord
+    @Binding var selectedMonth: Date
     
-    init(week: Week, dragProgress: CGFloat, hideDiffrentMonth: Bool = false, selectedDate: Binding<Date>, currentRecord: Binding<DropDownFilter>, calendarRecord: Binding<CalendarRecord>, monthDate: Date) {
+    init(week: Week, dragProgress: CGFloat, hideDiffrentMonth: Bool = false, selectedDate: Binding<Date>, currentRecord: Binding<DropDownFilter>, calendarRecord: Binding<CalendarRecord>, monthDate: Date, selectedMonth: Binding<Date>) {
         self.week = week
         self.dragProgress = dragProgress
         self.hideDiffrentMonth = hideDiffrentMonth
@@ -18,6 +19,7 @@ struct WeekView: View {
         self._currentRecord = currentRecord
         self._calendarRecord = calendarRecord
         self.monthDate = monthDate
+        self._selectedMonth = selectedMonth
     }
     
     var body: some View {
@@ -25,10 +27,10 @@ struct WeekView: View {
             ForEach(week.days, id: \.self) { cell in
                 DayView(
                     cell: cell,
-                    selectedDate: $selectedDate,
+                    monthDate: monthDate, selectedDate: $selectedDate,
                     currentRecord: $currentRecord,
                     calendarRecord: $calendarRecord,
-                    monthDate: monthDate
+                    selectedMonth: $selectedMonth
                 )
                 .frame(maxWidth: .infinity)
             }
@@ -41,3 +43,17 @@ struct WeekView: View {
     }
 }
 
+#Preview {
+    WeekView(
+        week: Week(
+            days: Calendar.currentWeek(from: .now).map { DayCell(date: $0) },
+            order: .current
+        ),
+        dragProgress: 1,
+        selectedDate: .constant(.now),
+        currentRecord: .constant(.all),
+        calendarRecord: .constant(CalendarRecord(statusCode: 200, code: "1", message: "Test Message", data: nil)),
+        monthDate: .now,
+        selectedMonth: .constant(.now)
+    )
+}


### PR DESCRIPTION
:orange_book: 작업 설명
> [!NOTE]
> 캘린더의 전 달 또는 다음달의 Cell 클릭 시 해당 Month로 이동하는 동작을 구현

> [!WARNING]
> scrollPosition에 withAnimation을 삽입하면 동작이 멈춰버는 문제가 있음. 