### PR TITLE
Feature/캘린더 DatePicker Mode UI/UX -> 바텀 시트로 변경 / ButtonStyle 확장 및 코드 정리

### DIFF
--- a/RecordManagment/Extensions/Common/Font+Extensions.swift
+++ b/RecordManagment/Extensions/Common/Font+Extensions.swift
@@ -130,3 +130,12 @@ extension Text {
             .kerning(style.letterSpacing)
     }
 }
+
+extension ButtonStyleConfiguration.Label {
+    func typography(_ style: Typography) -> some View {
+        self.font(style.font)
+            .fontWeight(style.weight)
+            .lineSpacing(style.lineHeight - style.size)
+            .kerning(style.letterSpacing)
+    }
+}

--- a/RecordManagment/Extensions/Components/Calendar/CalendarView.swift
+++ b/RecordManagment/Extensions/Components/Calendar/CalendarView.swift
@@ -11,7 +11,7 @@ struct MiddleSizePreferenceKey: PreferenceKey {
 struct CalendarView: View {
     @ObservedObject var vm: ViewModel // Calendar ViewModel
     @EnvironmentObject var sheetVM: MainSheetViewModel
-    @State private var datePickerSize: CGSize = .zero
+    @Binding var datePickerSize: CGSize
     let columns = Array(repeating: GridItem(.flexible(), spacing: 0), count: 7)
     var dragProgress: CGFloat = 1
     
@@ -21,41 +21,22 @@ struct CalendarView: View {
                 .padding(.bottom, 10)
                 .zIndex(1)
             Group {
-                if vm.dateMode {
-                    DatePicker(
-                        "", // 라벨 텍스트를 빈 문자열로
-                        selection: $vm.selectedMonth,
-                        displayedComponents: [.date] // 날짜만 선택
-                    )
-                    .datePickerStyle(.wheel)  // Wheel 스타일
-                    .labelsHidden()           // 라벨 숨김
-                    .font(.system(size: 28, weight: .bold))
-                    .frame(maxWidth: .infinity, maxHeight: datePickerSize.height + Calendar.monthHeight)
-                    .environment(\.locale, Locale(identifier: "ko_KR"))
-                    .scaleEffect(1.3)
-                    .clipped()
-                    .onChange(of: vm.selectedMonth) {
-                        vm.title = Calendar.monthAndYear(from: vm.selectedMonth)
-                        vm.date = vm.selectedMonth
+                middleDays
+                    .onPreferenceChange(MiddleSizePreferenceKey.self) { newSize in
+                        datePickerSize = newSize
                     }
-                } else {
-                    middleDays
-                        .onPreferenceChange(MiddleSizePreferenceKey.self) { newSize in
-                            datePickerSize = newSize
-                        }
-                    
-                    MonthCalendarView(
-                        isDragging: false,
-                        dragProgress: dragProgress,
-                        title: $vm.title,
-                        focused: $vm.focusedWeek,
-                        selection: $vm.date,
-                        currentRecord: $vm.currentRecord,
-                        calendarRecord: $vm.calendarRecord,
-                        selectedMonth: $vm.selectedMonth
-                    )
-                    .frame(maxHeight: Calendar.monthHeight)
-                }
+                
+                MonthCalendarView(
+                    isDragging: false,
+                    dragProgress: dragProgress,
+                    title: $vm.title,
+                    focused: $vm.focusedWeek,
+                    selection: $vm.date,
+                    currentRecord: $vm.currentRecord,
+                    calendarRecord: $vm.calendarRecord,
+                    selectedMonth: $vm.selectedMonth
+                )
+                .frame(maxHeight: Calendar.monthHeight)
             }
             .onChange(of: sheetVM.visibleToast) {
                 if sheetVM.visibleToast { // Toast가 활성화 되면 캘린더 업데이트
@@ -158,7 +139,7 @@ extension CalendarView {
                     repository: DefaultRecordRepository()
                 )
             )
-        )
+    ), datePickerSize: .constant(.zero)
     )
     .environmentObject(MainSheetViewModel(
         useCase: MainSheetUseCase(

--- a/RecordManagment/Extensions/Components/ChangeRecordAlertView.swift
+++ b/RecordManagment/Extensions/Components/ChangeRecordAlertView.swift
@@ -31,22 +31,14 @@ struct ChangeRecordAlertView: View {
                 }
                 .padding(.vertical, 24)
                 
-                Text("변경하기")
-                    .typography(.p16Medium)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 14)
-                    .foregroundStyle(selectedRecord != .none ? .white : Color.Primary.main())
-                    .background {
-                        RoundedRectangle(cornerRadius: 8)
-                            .foregroundStyle(selectedRecord != .none ? Color.Primary.main() : Color.Primary.lighter())
-                    }
-                    .onTapGesture {
-                        guard selectedRecord != .none else { return }
-                        self.currentRecord = selectedRecord
-                        self.selectedRecord = .none
-                        // closed screen
-                        self.isAlert = false
-                    }
+                Button("변경하기") {
+                    guard selectedRecord != .none else { return }
+                    self.currentRecord = selectedRecord
+                    self.selectedRecord = .none
+                    // closed screen
+                    self.isAlert = false
+                }
+                .seedDaysButtonStyle(type: selectedRecord != .none ? .success : .normal, state: .primary)
             }
             .padding(.vertical, 24)
             .padding(.horizontal, 20)

--- a/RecordManagment/Extensions/Components/DatePickerAlertView.swift
+++ b/RecordManagment/Extensions/Components/DatePickerAlertView.swift
@@ -40,27 +40,13 @@ struct DatePickerAlertView: View {
     
     private var buttons: some View {
         HStack {
-            Text("취소")
-                .typography(.p16Medium)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 14)
-                .background(Color.Gray._100())
-                .foregroundStyle(Color.Gray._400())
-                .clipShape(.rect(cornerRadius: 8))
-                .onTapGesture {
-                    cancel()
-                }
+            Button("취소") {
+                cancel()
+            }.seedDaysButtonStyle(type: .normal, state: .secondary)
             
-            Text("수정하기")
-                .typography(.p16Medium)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 14)
-                .background(Color.Primary.main())
-                .foregroundStyle(.white)
-                .clipShape(.rect(cornerRadius: 8))
-                .onTapGesture {
-                    update()
-                }
+            Button("수정하기") {
+                update()
+            }.seedDaysButtonStyle(type: .success, state: .primary)
         }
     }
 }

--- a/RecordManagment/Extensions/Components/LimitAlertView.swift
+++ b/RecordManagment/Extensions/Components/LimitAlertView.swift
@@ -15,17 +15,10 @@ struct LimitAlertView: View {
                     .typography(.p14Regular)
                     .padding(.bottom, 16)
                     .foregroundStyle(Color.Gray._600())
-                HStack(spacing: 10) {
-                    Text("확인")
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .background(Color.Primary.main())
-                        .foregroundStyle(.white)
-                        .clipShape(.rect(cornerRadius: 8))
-                        .onTapGesture {
-                            action()
-                        }
+                Button("확인") {
+                    action()
                 }
-                .frame(maxWidth: .infinity, maxHeight: 52)
+                .seedDaysButtonStyle(type: .success, state: .primary)
             }
             .padding()
             .frame(maxWidth: .infinity)

--- a/RecordManagment/Extensions/Components/RecordButton.swift
+++ b/RecordManagment/Extensions/Components/RecordButton.swift
@@ -1,10 +1,3 @@
-//
-//  RecordButton.swift
-//  RecordManagment
-//
-//  Created by 김용해 on 10/1/25.
-//
-
 import SwiftUI
 
 struct RecordButton: View {
@@ -13,20 +6,12 @@ struct RecordButton: View {
     let task: () async -> Void
     
     var body: some View {
-        VStack {
-            Text(method == .update ? "수정하기" : "작성하기")
-                .frame(maxWidth: .infinity)
-                .padding(14)
-                .background(condition ? Color.Primary.main() : Color.Primary.lighter())
-                .foregroundColor(condition ? .white : Color.Primary.light())
-                .cornerRadius(8)
-        }
-        .onTapGesture {
+        Button(method == .update ? "수정하기" : "작성하기") {
             guard condition else { return }
             Task {
                 await task()
             }
         }
-        .padding(.bottom)
+        .seedDaysButtonStyle(type: condition ? .success : .normal, state: .primary)
     }
 }

--- a/RecordManagment/Extensions/Components/SeedDayDatePickerSheet.swift
+++ b/RecordManagment/Extensions/Components/SeedDayDatePickerSheet.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+struct SeedDayDatePickerSheet: View {
+    
+    // View Properties
+    @State private var selection: Date
+    @Binding var dateMode: Bool
+    @Binding var selectedMonth: Date
+    @Binding var datePickerSize: CGSize
+    @Binding var title: String
+    @Binding var date: Date
+    
+    init(
+        dateMode: Binding<Bool>,
+        selectedMonth: Binding<Date>,
+        datePickerSize: Binding<CGSize>,
+        title: Binding<String>,
+        date: Binding<Date>
+    ) {
+        self._dateMode = dateMode
+        self._selectedMonth = selectedMonth
+        self._datePickerSize = datePickerSize
+        self._title = title
+        self._date = date
+        self.selection = selectedMonth.wrappedValue
+    }
+    
+    var body: some View {
+        VStack(spacing: 24) {
+            DatePicker(
+                "", // 라벨 텍스트를 빈 문자열로
+                selection: $selection,
+                displayedComponents: [.date] // 날짜만 선택
+            )
+            .datePickerStyle(.wheel)  // Wheel 스타일
+            .labelsHidden()           // 라벨 숨김
+            .font(.system(size: 28, weight: .bold))
+            .frame(maxWidth: .infinity, maxHeight: datePickerSize.height + Calendar.monthHeight)
+            .environment(\.locale, Locale(identifier: "ko_KR"))
+            .scaleEffect(1.1)
+            .clipped()
+            
+            HStack {
+                Button("오늘") {
+                    title = Calendar.monthAndYear(from: .now)
+                    selectedMonth = .now
+                    date = selectedMonth
+                    dateMode = false
+                }.seedDaysButtonStyle(type: .success, state: .secondary)
+                
+                Button("완료") {
+                    selectedMonth = selection
+                    title = Calendar.monthAndYear(from: selectedMonth)
+                    date = selectedMonth
+                    dateMode = false
+                }.seedDaysButtonStyle(type: .success, state: .secondary)
+            }
+        }
+        .padding(.vertical, 24)
+        .padding(.horizontal)
+        .presentationDetents([.fraction(0.4)])
+    }
+}
+
+#Preview {
+    SeedDayDatePickerSheet(
+        dateMode: .constant(true),
+        selectedMonth: .constant(.now),
+        datePickerSize: .constant(CGSize(width: 300, height: 300)),
+        title: .constant("2026년 1월"),
+        date: .constant(.now)
+    )
+}

--- a/RecordManagment/Extensions/Modifier/SeeDayButtonStyle.swift
+++ b/RecordManagment/Extensions/Modifier/SeeDayButtonStyle.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+
+// TODO: 상태값 2개를 통해 버튼 스타일 분류 ( type, state )
+enum ButtonType {
+    case normal
+    case success
+}
+
+enum ButtonState {
+    case primary
+    case secondary
+        
+}
+
+struct PrimaryButtonStyle: ButtonStyle {
+    let type: ButtonType
+    let state: ButtonState
+    
+    init(type: ButtonType, state: ButtonState) {
+        self.type = type
+        self.state = state
+    }
+    
+    var backgroundColor: Color {
+        switch (type, state) {
+            case (.normal,.primary):
+                Color.Primary.lighter()
+            case (.normal, .secondary):
+                    Color.Gray._100()
+            case (.success, .primary):
+                Color.Primary.main()
+            case (.success, .secondary):
+                Color.Gray._100()
+        }
+    }
+    
+    var foregroundColor: Color {
+        switch (type, state) {
+            case (.normal,.primary):
+                Color.Primary.main().opacity(0.4)
+            case (.normal, .secondary):
+                Color.Gray._400()
+            case (.success, .primary):
+                .white
+            case (.success, .secondary):
+                Color.Gray._900()
+        }
+    }
+    
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .typography(.p16Medium)
+            .frame(maxWidth: .infinity, maxHeight: 52)
+            .foregroundStyle(foregroundColor)
+            .background(backgroundColor)
+            .clipShape(.rect(cornerRadius: 8))
+            
+    }
+}
+
+extension View {
+    /// SeedDays 버튼 전용 스타일을 적용합니다.
+        ///
+        /// `ButtonType`과 `ButtonState` 조합에 따라
+        /// 버튼의 background, foreground 등 시각적 스타일을 일관되게 관리합니다.
+        ///
+        /// - Parameters:
+        ///   - type: 버튼의 역할을 정의하는 타입 값 (예: primary, secondary 등)
+        ///   - state: 버튼의 현재 상태 값 (예: normal, disabled, pressed 등)
+        ///
+        /// - Returns: 지정된 SeedDays 버튼 스타일이 적용된 View
+        ///
+        /// ### Example
+        /// ```swift
+        /// Button("확인") {
+        ///     submit()
+        /// }
+        /// .seedDaysButtonStyle(type: .primary, state: .normal)
+        /// ```
+    func seedDaysButtonStyle(type: ButtonType, state: ButtonState) -> some View {
+        self
+            .buttonStyle(PrimaryButtonStyle(type: type, state: state))
+    }
+}
+
+fileprivate struct SeeDayButtonStyle: View {
+    var body: some View {
+        VStack {
+            Button("Button") {
+                print("hello")
+            }
+            .seedDaysButtonStyle(type: .normal, state: .primary)
+            Button("Button") {
+                print("hello")
+            }
+            .seedDaysButtonStyle(type: .normal, state: .secondary)
+            Button("Button") {
+                print("hello")
+            }
+            .seedDaysButtonStyle(type: .success, state: .primary)
+            Button("Button") {
+                print("hello")
+            }
+            .seedDaysButtonStyle(type: .success, state: .secondary)
+        }
+    }
+}
+
+#Preview {
+    SeeDayButtonStyle()
+        .padding()
+}

--- a/RecordManagment/Presentation/View/Main/MainSheet.swift
+++ b/RecordManagment/Presentation/View/Main/MainSheet.swift
@@ -10,6 +10,7 @@ struct MainSheet: View {
     @EnvironmentObject private var vm: MainSheetViewModel
     
     // View Properties
+    @State private var datePickerSize: CGSize = .zero
     var offset: CGFloat
     var topDetent: CGFloat
     
@@ -37,6 +38,16 @@ struct MainSheet: View {
                 .padding(.vertical, 10)
 
             scrollContent
+        }
+        .sheet(isPresented: $calendarVM.dateMode) {
+            
+            SeedDayDatePickerSheet(
+                dateMode: $calendarVM.dateMode,
+                selectedMonth: $calendarVM.selectedMonth,
+                datePickerSize: $datePickerSize,
+                title: $calendarVM.title,
+                date: $calendarVM.date
+            )
         }
         .background(Color(.systemBackground))
         .frame(height: UIScreen.main.bounds.height)
@@ -76,7 +87,7 @@ struct MainSheet: View {
                         
                         vm.scrollOffset = -minY
                     }
-                CalendarView(vm: calendarVM)
+                CalendarView(vm: calendarVM, datePickerSize: $datePickerSize)
                     .environmentObject(vm)
                     .padding(.top, 9)
                 

--- a/RecordManagment/Presentation/View/OnBoarding/FinalOnBoardingView.swift
+++ b/RecordManagment/Presentation/View/OnBoarding/FinalOnBoardingView.swift
@@ -55,7 +55,7 @@ struct FinalOnBoardingView: View {
             Spacer()
             Spacer()
             if visibleBoxes.indices.contains(3) {
-                Button(action: {
+                Button("시작하기") {
                     Task {
                         if sm.firstOnBoarding {
                             switch await sm.completeOnBoarding() {
@@ -73,14 +73,8 @@ struct FinalOnBoardingView: View {
                             }
                         }
                     }
-                }, label: {
-                    Text("시작하기")
-                        .frame(maxWidth: .infinity)
-                        .padding(14)
-                        .background(Color.Primary.main())
-                        .foregroundColor(.white)
-                        .cornerRadius(8)
-                })
+                }
+                .seedDaysButtonStyle(type: .success, state: .primary)
                 .opacity(visibleBoxes[3] ? 1 : 0)
                 .animation(.easeInOut(duration: 1.4), value: visibleBoxes[3])
             }
@@ -133,8 +127,10 @@ struct FinalOnBoardingView: View {
     }
 }
 
-//#Preview {
-//    FinalOnBoardingView(toastMessage: "Test용입니다")
-//        .environmentObject(SectionView.ViewModel())
-//        .environmentObject(RouterView.ViewModel())
-//}
+#Preview {
+    FinalOnBoardingView(toastMessage: "Test용입니다")
+        .environmentObject(SectionView.ViewModel(
+            useCase: .init(repository: DefaultSectionRepository())
+        ))
+        .environmentObject(Coordinator())
+}

--- a/RecordManagment/Presentation/View/OnBoarding/SectionView.swift
+++ b/RecordManagment/Presentation/View/OnBoarding/SectionView.swift
@@ -45,7 +45,7 @@ struct SectionView: View {
                         SectionFiveView(currentProgress: $vm.currentProgress)
                 }
                 
-                Button(action: {
+                Button(vm.currentProgress == .notification ? "완료하기" : "다음") {
                     // 알림 허용 기능
                     if vm.currentProgress == .notification {
                         Task {
@@ -66,15 +66,8 @@ struct SectionView: View {
                     } else {
                         next(vm.currentProgress)
                     }
-                }, label: {
-                    Text(vm.currentProgress == .notification ? "완료하기" : "다음")
-                        .typography(.p16Medium)
-                        .frame(maxWidth: .infinity)
-                        .padding(14)
-                        .background(isNextDisabled ? Color.Primary.lighter() : Color.Primary.main())
-                        .foregroundColor(isNextDisabled ? Color.Primary.light() : .white)
-                        .cornerRadius(8)
-                })
+                }
+                .seedDaysButtonStyle(type: isNextDisabled ? .normal : .success, state: .primary)
                 .disabled(isNextDisabled)
             }
             .padding()

--- a/RecordManagment/Presentation/View/Setting/NickNameChangeView.swift
+++ b/RecordManagment/Presentation/View/Setting/NickNameChangeView.swift
@@ -44,18 +44,10 @@ struct NickNameChangeView: View {
     }
     
     private func recordButton(condition: Binding<Bool>, task: @escaping() -> Void) -> some View {
-        VStack {
-            Text("변경하기")
-                .frame(maxWidth: .infinity)
-                .padding(14)
-                .background(condition.wrappedValue ? Color.Primary.main() : Color.Primary.lighter())
-                .foregroundColor(condition.wrappedValue ? .white : Color.Primary.light())
-                .cornerRadius(8)
-        }
-        .onTapGesture {
+        Button("변경하기") {
             guard condition.wrappedValue else { return }
             task()
-        }
+        }.seedDaysButtonStyle(type: condition.wrappedValue ? .success : .normal, state: .primary)
     }
 }
 


### PR DESCRIPTION
:link: 관련 이슈

:orange_book: 작업 설명
기존 DatePicker wheel만 있던 UI를 Bottom Sheet로 전향 
기존 버튼 디자인 Componenet에서 확장을 하기위해 ButtonStyle 별로 상태값에 따라 구현

:test_tube: 테스트 내역 (선택)

:camera_with_flash: 스크린샷 또는 시연 영상 (선택)

:speech_balloon: 추가 설명 or 리뷰 포인트 (선택)