### PR TITLE
앱 리뷰 Dialog 노출 로직 추가 및 연결합니다.

### DIFF
--- a/RecordManagment.xcodeproj/project.pbxproj
+++ b/RecordManagment.xcodeproj/project.pbxproj
@@ -465,7 +465,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.7;
+				MARKETING_VERSION = 1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yongms.RecordManagment;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -506,7 +506,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.7;
+				MARKETING_VERSION = 1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yongms.RecordManagment;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/RecordManagment/ContentView.swift
+++ b/RecordManagment/ContentView.swift
@@ -1,10 +1,3 @@
-//
-//  ContentView.swift
-//  RecordManagment
-//
-//  Created by 김용해 on 7/22/25.
-//
-
 import SwiftUI
 
 struct ContentView: View {

--- a/RecordManagment/Data/Record/DefaultHabitRecordRepository.swift
+++ b/RecordManagment/Data/Record/DefaultHabitRecordRepository.swift
@@ -62,10 +62,11 @@ struct DefaultHabitRecordRepository: HabitRecordRepository {
         }
         
         switch result {
-            case .success(let data):
-                return .success(data)
-            case .failure(let error):
-                return .failure(error)
+        case .success(let data):
+            AppReviewManager.shared.markRecordCreated()
+            return .success(data)
+        case .failure(let error):
+            return .failure(error)
         }
     }
     

--- a/RecordManagment/Data/Record/DefaultRecordRepository.swift
+++ b/RecordManagment/Data/Record/DefaultRecordRepository.swift
@@ -12,13 +12,19 @@ struct DefaultRecordRepository: RecordRepository {
     }
     
     func submit<T, V>(method: RecordMethod, selectedImages: [PhotoTransfer], makeForm: @MainActor ([String]) -> T, create: (T) async -> Result<V, LoginError>, update: (T) async -> Result<V, LoginError>) async -> Result<V, LoginError> {
-        await manager.submitRecord(
+        let result = await manager.submitRecord(
             method: method,
             selectedImages: selectedImages,
             makeForm: makeForm,
             create: create,
             update: update
         )
+        
+        if case .success = result {
+            AppReviewManager.shared.markRecordCreated()
+        }
+        
+        return result
     }
     
     func delete<T: Decodable>(recordId: String, type: String) async -> Result<T, LoginError> {

--- a/RecordManagment/Data/User/AppReviewManager.swift
+++ b/RecordManagment/Data/User/AppReviewManager.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+final class AppReviewManager {
+    static let shared = AppReviewManager()
+    
+    private let firstLaunchDateKey = "firstLaunchDate"
+    private let hasCompletedRecordKey = "hasCompletedRecord"
+    private let hasShownReviewAlertKey = "hasShownReviewAlert"
+    
+    private init() {}
+    
+    /// 앱 첫 실행 날짜를 기록합니다 (이미 기록되어 있다면 유지).
+    func trackFirstLaunch() {
+        if UserDefaults.standard.object(forKey: firstLaunchDateKey) == nil {
+            UserDefaults.standard.set(Date(), forKey: firstLaunchDateKey)
+        }
+    }
+    
+    /// 사용자가 기록을 완료했음을 기록합니다.
+    func markRecordCreated() {
+        UserDefaults.standard.set(true, forKey: hasCompletedRecordKey)
+    }
+    
+    /// 리뷰 요청 조건이 충족되었는지 확인하고, 충족되었다면 true를 반환합니다.
+    /// 외부(UseCase 등)에서 이 값이 true일 때 UI 알림을 띄워 처리할 수 있습니다.
+    /// 조건: 설치 후 1일 경과 && 최소 1회 기록 완료 && 한 번도 띄운 적 없음
+    func shouldRequestReview() -> Bool {
+        // 한 번이라도 알림을 띄우기로 한 적이 있다면 통과
+        if UserDefaults.standard.bool(forKey: hasShownReviewAlertKey) {
+            return false
+        }
+        
+        guard let firstLaunchDate = UserDefaults.standard.object(forKey: firstLaunchDateKey) as? Date else {
+            return false
+        }
+        
+        let hasCompletedRecord = UserDefaults.standard.bool(forKey: hasCompletedRecordKey)
+        let oneDayInSeconds: TimeInterval = 24 * 60 * 60
+        let timePassed = Date().timeIntervalSince(firstLaunchDate)
+        
+        // 조건 체크: 1일 경과 및 기록 완료 여부
+        if timePassed >= oneDayInSeconds && hasCompletedRecord {
+            // 이번 반환 후 알림이 뜰 것이므로, flag 활성화
+            UserDefaults.standard.set(true, forKey: hasShownReviewAlertKey)
+            return true
+        }
+        
+        return false
+    }
+    
+#if DEBUG
+    /// 디버그용: 앱 리뷰 조건을 강제로 만족시키도록 UserDefault를 조작합니다. (사용법: 테스트 버튼이나 onAppear 등에서 호출)
+    func forceAppReviewConditionsForTesting() {
+        let pastDate = Date().addingTimeInterval(-24 * 60 * 60 * 2) // 2일 전
+        UserDefaults.standard.set(pastDate, forKey: firstLaunchDateKey)
+        UserDefaults.standard.set(true, forKey: hasCompletedRecordKey)
+        UserDefaults.standard.set(false, forKey: hasShownReviewAlertKey)
+    }
+    
+    /// 디버그용: 앱 리뷰 관련 UserDefault 기록을 모두 초기화합니다.
+    func resetAppReviewConditionsForTesting() {
+        UserDefaults.standard.removeObject(forKey: firstLaunchDateKey)
+        UserDefaults.standard.removeObject(forKey: hasCompletedRecordKey)
+        UserDefaults.standard.removeObject(forKey: hasShownReviewAlertKey)
+    }
+#endif
+}

--- a/RecordManagment/Extensions/Components/AppReviewAlert.swift
+++ b/RecordManagment/Extensions/Components/AppReviewAlert.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+
+struct AppReviewAlert: View {
+    @EnvironmentObject var coordinator: Coordinator
+    
+    let cancel: () -> Void
+    let action: () -> Void
+    
+    init(cancel: @escaping() -> Void, action: @escaping() -> Void) {
+        self.cancel = cancel
+        self.action = action
+    }
+    
+    var body: some View {
+        ZStack {
+            Color(hex: "#222222").opacity(0.5)
+                .ignoresSafeArea()
+            
+            VStack {
+                Text("리뷰를 남겨주세요!")
+                    .typography(.p16SemiBold)
+                    .padding(.bottom,8)
+                Text("저희 앱이 조금이나마 도움이 되고 있나요?\n잠시만 시간을 내어 리뷰를 남겨주시면, 씨드데이에\n큰 도움이 됩니다. 감사합니다.")
+                    .typography(.p14Regular)
+                    .foregroundStyle(Color.Gray._600())
+                    .padding(.bottom, 16)
+                    .multilineTextAlignment(.center)
+                HStack {
+                    alertBox("나중에", bgColor: Color.Gray._100(), textColor: Color.Gray._400(), action: cancel)
+                    alertBox("별점 주기", bgColor: Color.Primary.main(), textColor: .white) {
+                        cancel()
+                        Task {
+                            action()
+                        }
+                    }
+                }
+            }
+            .padding()
+            .frame(maxWidth: .infinity)
+            .toolbarBackgroundVisibility(.hidden, for: .navigationBar)
+            .background(
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(Color.white)
+            )
+            .padding(.horizontal, 32)
+        }
+    }
+    
+    private func alertBox(
+        _ text: String,
+        bgColor: Color,
+        textColor: Color,
+        action: @escaping() -> Void
+    ) -> some View {
+        Text(text)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+            .background(bgColor)
+            .foregroundStyle(textColor)
+            .clipShape(.rect(cornerRadius: 8))
+            .onTapGesture {
+                action()
+            }
+    }
+}

--- a/RecordManagment/Extensions/Modifier/AppReviewStyle.swift
+++ b/RecordManagment/Extensions/Modifier/AppReviewStyle.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct AppReviewStyle: ViewModifier {
+    @Binding var isShow: Bool
+    let cancel: () -> Void
+    let action: () -> Void
+    
+    init(isShow: Binding<Bool>, cancel: @escaping () -> Void, action: @escaping () -> Void) {
+        self._isShow = isShow
+        self.cancel = cancel
+        self.action = action
+    }
+    
+    func body(content: Content) -> some View {
+        content
+            .overlay {
+                if isShow {
+                    AppReviewAlert(cancel: cancel, action: action)
+                }
+            }
+    }
+}
+
+extension View {
+    
+    @ViewBuilder
+    func showAppReviewAlert(
+        isShow: Binding<Bool>,
+        cancel: @escaping () -> Void,
+        action: @escaping () -> Void
+    ) -> some View {
+        self.modifier(
+            AppReviewStyle(
+                isShow: isShow,
+                cancel: cancel,
+                action: action,
+            )
+        )
+    }
+}
+

--- a/RecordManagment/Presentation/View/Main/MainView.swift
+++ b/RecordManagment/Presentation/View/Main/MainView.swift
@@ -14,7 +14,7 @@ struct MainView: View {
     @State private var navBarHeight: CGFloat = 0
     @State private var isShow: Bool = false
     @State private var isGoalReset: Bool = false
-    
+    @State private var isAppReviewShow: Bool = false
     var body: some View {
         ZStack(alignment: .top) {
             NavigationBarProxy { _ , navBar, _ in
@@ -137,6 +137,14 @@ struct MainView: View {
         ) {
          coordinator.push(.goalSelection)
         }
+        .showAppReviewAlert(isShow: $isAppReviewShow, cancel: {
+            isAppReviewShow = false
+        }, action: {
+            isAppReviewShow = false
+            if let url = URL(string: "https://apps.apple.com/kr/app/%EC%94%A8%EB%93%9C-%EB%8D%B0%EC%9D%B4/id6753913555") {
+                UIApplication.shared.open(url)
+            }
+        })
         .toolbar {
             if isTutorial && !isShow {
                 switch sheetVM.sheetState {
@@ -208,6 +216,15 @@ struct MainView: View {
         .toolbarBackgroundVisibility(.hidden, for: .navigationBar)
         .navigationBarBackButtonHidden()
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+#if DEBUG
+            // 테스트용: 리뷰 조건을 강제로 만족시킴
+            AppReviewManager.shared.forceAppReviewConditionsForTesting()
+#endif
+            if AppReviewManager.shared.shouldRequestReview() {
+                isAppReviewShow = true
+            }
+        }
     }
 }
 

--- a/RecordManagment/RecordManagmentApp.swift
+++ b/RecordManagment/RecordManagmentApp.swift
@@ -1,10 +1,3 @@
-//
-//  RecordManagmentApp.swift
-//  RecordManagment
-//
-//  Created by 김용해 on 7/22/25.
-//
-
 import SwiftUI
 import KakaoSDKAuth
 import KakaoSDKCommon
@@ -17,6 +10,7 @@ struct RecordManagmentApp: App {
         if let apiKey = Bundle.main.infoDictionary?["KAKAO_API_KEY"] as? String {
             KakaoSDK.initSDK(appKey: apiKey)
         }
+        AppReviewManager.shared.trackFirstLaunch()
     }
     
     var body: some Scene {


### PR DESCRIPTION

### 📝 PR Release Note

#### 🚀 목적 (Goals)
사용자 피드백 확보를 위해 특정 조건 충족 시 앱 리뷰 다이얼로그를 노출하는 기능을 구현하고, 개발 효율을 위해 환경별(Debug/Release) 동작을 분기 처리했습니다.

#### 🛠 주요 변경 사항 (Core Changes)
1.  **앱 리뷰 노출 조건 구현 (`AppReviewManager`)**
    *   앱 최초 실행 후 **1일 경과** 및 **최소 1회 기록 완료** 시 리뷰 요청 조건 충족.
    *   중복 노출 방지를 위해 `hasShownReviewAlert` 플래그 관리.
2.  **환경별(Debug/Release) 로직 분기**
    *   **Debug Build**: `#if DEBUG` 블록을 통해 `forceAppReviewConditionsForTesting()`을 호출, 개발 중 즉시 리뷰 다이얼로그를 확인하고 테스트할 수 있도록 처리.
    *   **Release Build**: 실제 설정된 조건(기간/기록 횟수)을 엄격하게 준수하여 실사용자에게 노출.
3.  **UI 연동 (`MainView`)**
    *   `MainView`의 `onAppear` 시점에 `AppReviewManager`의 상태를 체크하여 다이얼로그(Alert)를 노출하도록 연결.

#### 🧪 테스트 방법 (Test Plan)
*   **Debug**: 앱 실행 시 즉시 리뷰 알럿이 뜨는지 확인.
*   **Release**: 조건(1일 경과 등) 미충족 시 알럿이 뜨지 않는지 로직 검토.

---